### PR TITLE
Customization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,19 @@
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        import sys
+        cmdline = ' -v --doctest-module --cov surt surt/'
+        errcode = pytest.main(cmdline)
+        sys.exit(errcode)
+
+
 setup(name='surt',
       version='0.2',
       author='rajbot',
@@ -15,4 +30,8 @@ setup(name='surt',
       provides=[ 'surt' ],
       packages=[ 'surt' ],
       scripts=[],
+      # Tests
+      tests_require=[ 'pytest' ],
+      test_suite='',
+      cmdclass={'test': PyTest},
      )

--- a/surt/handyurl.py
+++ b/surt/handyurl.py
@@ -200,7 +200,11 @@ class handyurl(object):
 
     # getURLString()
     #___________________________________________________________________________
-    def getURLString(self, surt=False, public_suffix=False):
+    def getURLString(self,
+                     surt=False,
+                     public_suffix=False,
+                     trailing_comma=False,
+                     **options):
 
         if None != self.opaque:
             return self.opaque
@@ -229,6 +233,8 @@ class handyurl(object):
             s += ":%d" % self.port
 
         if surt:
+            if trailing_comma:
+                s += ','
             s += ')'
 
         hasPath = (None != self.path) and (len(self.path) > 0)


### PR DESCRIPTION
- Make 'python setup.py test' run doctest with coverage
- surt() command now supports arbitrary options, passed to canonicalizers
- surt(url, trailing_comma=True) will produce a surt with trailing comma restored,
eg: surt('example.com', trailing_comma=True) returns 'com,example,)/'