### PR TITLE
port new fix: …

### DIFF
--- a/surt/IAURLCanonicalizer.py
+++ b/surt/IAURLCanonicalizer.py
@@ -58,6 +58,10 @@ def canonicalize(url, host_lowercase=True, host_massage=True,
     'http://archive.org/big'
     >>> canonicalize(handyurl.parse("dns:www.archive.org")).getURLString()
     'dns:www.archive.org'
+    >>> canonicalize(handyurl.parse("http://www.nsf.gov/statistics/sed/2009/SED_2009.zip?CFID=14387305&CFTOKEN=72942008&jsessionid=f030eacc7e49c4ca0b077922347418418766")).getURLString()
+    'http://nsf.gov/statistics/sed/2009/sed_2009.zip?jsessionid=f030eacc7e49c4ca0b077922347418418766'
+    >>> canonicalize(handyurl.parse("http://www.nsf.gov/statistics/sed/2009/SED_2009.zip?CFID=14387305&CFTOKEN=72942008")).getURLString()
+    'http://nsf.gov/statistics/sed/2009/sed_2009.zip'
     """
     if host_lowercase and url.host:
         url.host = url.host.lower()
@@ -94,17 +98,15 @@ def canonicalize(url, host_lowercase=True, host_massage=True,
 
     query = url.query
     if query:
-        if '' == query and query_strip_empty:
-            query = None
-        elif len(query) > 0:
+        if len(query) > 0:
             if query_strip_session_id:
-                #This function expects the query to start with a '?'
-                query = stripQuerySessionID('?'+query)
-                query = query[1:] #now strip off '?' that we just added
+                query = stripQuerySessionID(query)
             if query_lowercase:
                 query = query.lower()
             if query_alpha_reorder:
                 query = alphaReorderQuery(query)
+        if '' == query and query_strip_empty:
+            query = None
         url.query = query
     else:
         if query_strip_empty:

--- a/surt/URLRegexTransformer.py
+++ b/surt/URLRegexTransformer.py
@@ -66,7 +66,7 @@ def stripPathSessionID(path):
 
 # stripQuerySessionID
 #_______________________________________________________________________________
-def stripQuerySessionID(path):
+def stripQuerySessionID(query):
     """These doctests are from IAURLCanonicalizerTest.java:
 
     >>> #base = "http://www.archive.org/index.html"
@@ -148,22 +148,22 @@ def stripQuerySessionID(path):
     '?requestID=200608200458360%2E39414378'
 
     """
-    patterns = [re.compile("^(.+)(?:jsessionid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
-                re.compile("^(.+)(?:phpsessid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
-                re.compile("^(.+)(?:sid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
-                re.compile("^(.+)(?:ASPSESSIONID[a-zA-Z]{8}=[a-zA-Z]{24})(?:&(.*))?$", re.I),
-                re.compile("^(.+)(?:cfid=[^&]+&cftoken=[^&]+)(?:&(.*))?$", re.I),
+    patterns = [re.compile("^(.*)(?:jsessionid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
+                re.compile("^(.*)(?:phpsessid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
+                re.compile("^(.*)(?:sid=[0-9a-zA-Z]{32})(?:&(.*))?$", re.I),
+                re.compile("^(.*)(?:ASPSESSIONID[a-zA-Z]{8}=[a-zA-Z]{24})(?:&(.*))?$", re.I),
+                re.compile("^(.*)(?:cfid=[^&]+&cftoken=[^&]+)(?:&(.*))?$", re.I),
                ]
 
     for pattern in patterns:
-        m = pattern.match(path)
+        m = pattern.match(query)
         if m:
             if m.group(2):
-                path = m.group(1) + m.group(2)
+                query = m.group(1) + m.group(2)
             else:
-                path = m.group(1)
+                query = m.group(1)
 
-    return path
+    return query
 
 
 # hostToSURT


### PR DESCRIPTION
https://github.com/internetarchive/webarchive-commons/pull/17/commits/0cc72a1c3d1db464d27a3fe8d89e4138e28be171 -- Make canonicalizer be able to strip session id params even if they are the first params in the query string. And add session id strip test.
