### PR TITLE
Fix string literals causing DeprecationWarning: invalid escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea/
 *.pyc
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,8 @@ sudo: false
 
 language: python
 python:
-    - 2.6
     - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
     - 3.6
-    - nightly
-    - pypy
-    - pypy3
 
 install: pip install . pytest pytest-cov
 script: py.test -v --cov=surt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ python:
     - 2.7
     - 3.6
 
-install: pip install . pytest pytest-cov
+install: pip install . pytest>=3.6 pytest-cov
 script: py.test -v --cov=surt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ python:
     - 2.7
     - 3.6
 
-install: pip install . pytest>=3.6 pytest-cov
+install: pip install --upgrade . pytest pytest-cov
 script: py.test -v --cov=surt

--- a/surt/GoogleURLCanonicalizer.py
+++ b/surt/GoogleURLCanonicalizer.py
@@ -165,7 +165,7 @@ def escapeOnce(input):
     """escape everything outside of 32-128, except #"""
     if input:
         return quote_from_bytes(
-                input, safe=b'''!"$&'()*+,-./:;<=>?@[\]^_`{|}~''').encode(
+                input, safe=br'''!"$&'()*+,-./:;<=>?@[\]^_`{|}~''').encode(
                         'ascii')
     else:
         return input

--- a/surt/IAURLCanonicalizer.py
+++ b/surt/IAURLCanonicalizer.py
@@ -124,7 +124,7 @@ def alphaReorderQuery(orig):
 
 # massageHost()
 #_______________________________________________________________________________
-_RE_WWWDIGITS = re.compile(b'www\d*\.')
+_RE_WWWDIGITS = re.compile(br'www\d*\.')
 
 def massageHost(host):
     m = _RE_WWWDIGITS.match(host)

--- a/surt/URLRegexTransformer.py
+++ b/surt/URLRegexTransformer.py
@@ -28,8 +28,8 @@ import re
 # stripPathSessionID
 #_______________________________________________________________________________
 _RES_PATH_SESSIONID = [
-    re.compile(b"^(.*/)(\((?:[a-z]\([0-9a-z]{24}\))+\)/)([^\?]+\.aspx.*)$", re.I),
-    re.compile(b"^(.*/)(\\([0-9a-z]{24}\\)/)([^\\?]+\\.aspx.*)$", re.I),
+    re.compile(br"^(.*/)(\((?:[a-z]\([0-9a-z]{24}\))+\)/)([^\?]+\.aspx.*)$", re.I),
+    re.compile(br"^(.*/)(\([0-9a-z]{24}\)/)([^\?]+\.aspx.*)$", re.I),
     ]
 
 def stripPathSessionID(path):

--- a/surt/handyurl.py
+++ b/surt/handyurl.py
@@ -34,7 +34,7 @@ except:
 from surt.URLRegexTransformer import hostToSURT
 
 _RE_MULTIPLE_PROTOCOLS = re.compile(br'^(https?://)+')
-_RE_HAS_PROTOCOL = re.compile(b"^([a-zA-Z][a-zA-Z0-9\+\-\.]*):")
+_RE_HAS_PROTOCOL = re.compile(br"^([a-zA-Z][a-zA-Z0-9\+\-\.]*):")
 _RE_SPACES = re.compile(b'[\n\r\t]')
 
 class handyurl(object):
@@ -78,7 +78,7 @@ class handyurl(object):
         self.last_delimiter = last_delimiter #added in python version
 
 
-    '''
+    r'''
     RFC 2396-inspired regex.
 
     From the RFC Appendix B:


### PR DESCRIPTION
Use of `\` in string literals not marked by `'r'` to indicate raw string literal will give an DeprecationWarning.

This PR fixes the string literals involved.