### PR TITLE
Fix minor py37+ issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ python:
     - pypy
     - pypy3
 
-install: pip install 'setuptools<45' . 'pytest<5' 'zipp<2' pytest-cov
+install: pip install 'setuptools<45' . 'pytest<5' 'zipp<2' 'pytest-cov<2.10.0'
 script: py.test -v --cov=surt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ sudo: false
 
 language: python
 python:
-    - 2.6
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - nightly
     - pypy
     - pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
     - nightly
     - pypy
     - pypy3
 
-install: pip install . pytest pytest-cov
+install: pip install 'setuptools<45' . 'pytest<5' 'zipp<2' pytest-cov
 script: py.test -v --cov=surt

--- a/surt/GoogleURLCanonicalizer.py
+++ b/surt/GoogleURLCanonicalizer.py
@@ -140,6 +140,8 @@ def attemptIPFormats(host):
         m = DECIMAL_IP.match(host)
         if m:
             try:
+                if isinstance(host, bytes):
+                    host = host.decode('utf-8')
                 return socket.gethostbyname_ex(host)[2][0].encode('ascii')
             except (socket.gaierror, socket.herror):
                 return None
@@ -147,6 +149,8 @@ def attemptIPFormats(host):
             m = OCTAL_IP.match(host)
             if m:
                 try:
+                    if isinstance(host, bytes):
+                        host = host.decode('utf-8')
                     return socket.gethostbyname_ex(host)[2][0].encode('ascii')
                 except socket.gaierror:
                     return None

--- a/surt/handyurl.py
+++ b/surt/handyurl.py
@@ -34,7 +34,7 @@ except:
 from surt.URLRegexTransformer import hostToSURT
 
 _RE_MULTIPLE_PROTOCOLS = re.compile(br'^(https?://)+')
-_RE_HAS_PROTOCOL = re.compile(b"^([a-zA-Z][a-zA-Z0-9\+\-\.]*):")
+_RE_HAS_PROTOCOL = re.compile(br"^([a-zA-Z][a-zA-Z0-9\+\-\.]*):")
 _RE_SPACES = re.compile(b'[\n\r\t]')
 
 class handyurl(object):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     py26, py27,
-    py33, py34, py35, py36
+    py33, py34, py35, py36, py37
     pypy, pypy3,
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@
 
 [tox]
 envlist =
-    py26, py27,
-    py33, py34, py35, py36, py37
+    py27,
+    py34, py35, py36, py37
     pypy, pypy3,
 
 [testenv]


### PR DESCRIPTION
Add testing for `py37` and `py38, remove `py26` and `py33.

Fix bytes/str issue that caused `pypy3` tests to fail.

Update `.travis.ci` to limit versions of `pytest`, `pytest-cov` to allow tests to run in all python versions.

Resolve py37+ warnings like the following by adding `r` prefix to that regex.
```
surt/handyurl.py:37: DeprecationWarning: invalid escape sequence \+
    _RE_HAS_PROTOCOL = re.compile(b"^([a-zA-Z][a-zA-Z0-9\+\-\.]*):")
```

