### PR TITLE
Travis CI: Lint Python code for syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
     - 3.8
     - nightly
     - pypy3
-
+jobs:
+  allow_failures:
+    - python: pypy3
 install: pip install flake8 pytest pytest-cov .
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: py.test -v --cov=surt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: focal
 language: python
 python:
     - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
-# http://docs.travis-ci.com/user/migrating-from-legacy/
-sudo: false
-
 language: python
 python:
-    - 2.6
     - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
     - 3.6
+    - 3.7
+    - 3.8
     - nightly
-    - pypy
     - pypy3
 
-install: pip install . pytest pytest-cov
+install: pip install flake8 pytest pytest-cov .
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: py.test -v --cov=surt

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 
 [tox]
 envlist =
-    py26, py27,
-    py33, py34, py35, py36
-    pypy, pypy3,
+    py27,
+    py36, py37, py38,
+    pypy3,
 
 [testenv]
 deps =
@@ -15,7 +15,7 @@ deps =
 commands = py.test -v {posargs}
 
 [testenv:cov]
-basepython = python2.7
+basepython = python3.8
 skip_install = true
 usedevelop = true
 deps =


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.