### PR TITLE
Remove unnecessary shebangs

### DIFF
--- a/surt/DefaultIAURLCanonicalizer.py
+++ b/surt/DefaultIAURLCanonicalizer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.
 #
 # This file is part of the `surt` python package.

--- a/surt/GoogleURLCanonicalizer.py
+++ b/surt/GoogleURLCanonicalizer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.

--- a/surt/IAURLCanonicalizer.py
+++ b/surt/IAURLCanonicalizer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.
 #
 # This file is part of the `surt` python package.

--- a/surt/URLRegexTransformer.py
+++ b/surt/URLRegexTransformer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.
 #
 # This file is part of the `surt` python package.

--- a/surt/__init__.py
+++ b/surt/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.
 #
 # This file is part of the `surt` python package.

--- a/surt/handyurl.py
+++ b/surt/handyurl.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.

--- a/surt/surt.py
+++ b/surt/surt.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright(c)2012-2013 Internet Archive. Software license AGPL version 3.
 #
 # This file is part of the `surt` python package.


### PR DESCRIPTION
These aren't actually necessary, and may end up causing issues on distributions that do not ship a `/usr/bin/python` by default.