### PR TITLE
Don't perform www. prefix removal on 2nd level domains. Fixes #28

### DIFF
--- a/surt/IAURLCanonicalizer.py
+++ b/surt/IAURLCanonicalizer.py
@@ -124,12 +124,12 @@ def alphaReorderQuery(orig):
 
 # massageHost()
 #_______________________________________________________________________________
-_RE_WWWDIGITS = re.compile(b'www\d*\.')
+_RE_WWWDIGITS = re.compile(rb'(www\d*\.).+\.')
 
 def massageHost(host):
     m = _RE_WWWDIGITS.match(host)
     if m:
-        return host[len(m.group(0)):]
+        return host[len(m.group(1)):]
     else:
         return host
 

--- a/tests/test_surt.py
+++ b/tests/test_surt.py
@@ -284,7 +284,11 @@ def test_surt():
     assert surt.surt("dns:alexa.com") == 'dns:alexa.com'
     assert surt.surt("dns:archive.org") == 'dns:archive.org'
 
+    assert surt.surt("http://www1234.com/") == 'com,www1234)/'
     assert surt.surt("http://www.archive.org/") == 'org,archive)/'
+    assert surt.surt("https://www.archive.org/") == 'org,archive)/'
+    assert surt.surt("http://www1.archive.org/") == 'org,archive)/'
+    assert surt.surt("http://www1.www.archive.org/") == 'org,archive,www)/'
     assert surt.surt("http://archive.org/") == 'org,archive)/'
     assert surt.surt("http://archive.org/goo/") == 'org,archive)/goo'
     assert surt.surt("http://archive.org/goo/?") == 'org,archive)/goo'
@@ -362,7 +366,7 @@ def test_surt_ipaddress(url, opts, out):
         ])
 def test_surt_return_type(burl):
     """surt.surt() returns the same type of string object (i.e. returns unicode
-    string for unicode string input, and byets for bytes)
+    string for unicode string input, and bytes for bytes)
 
     Note this behavior may change in the future versions. This test is for
     testing compatibility until that happens.


### PR DESCRIPTION
Fixes #28 Require at least two dots (.) in domain name when we're matching WWWnnnn. prefixes to prevent removal of second level domains that match.